### PR TITLE
Connect With Frontend

### DIFF
--- a/src/controller/StudentController.ts
+++ b/src/controller/StudentController.ts
@@ -58,17 +58,8 @@ export class StudentController {
                             where[param] = Raw(alias => `LOWER(${alias}) LIKE '%${value.toLowerCase()}%'`);
                             break;
                         case 'gpa':
-                            const hasMin = value.hasOwnProperty('min');
-                            const hasMax = value.hasOwnProperty('max');
-                            if (hasMin && hasMax) {
-                                where[param] = Between(value.min, value.max);
-                            } else if (hasMax) {
-                                where[param] = LessThanOrEqual(value.max);
-                            } else if (hasMin) {
-                                where[param] = MoreThanOrEqual(value.min);
-                            } else {
-                                where[param] = Equal(value);
-                            }
+                            //order of min and max don't matter for Between
+                            where[param] = Between(value[0], value[1]);
                             break;
                         default:
                             break;

--- a/src/entity/Enums.ts
+++ b/src/entity/Enums.ts
@@ -25,7 +25,7 @@ export enum StudentStatus {
     ENROLLED= 'ENROLLED',
     LEAVE = 'LEAVE',
     DROP_BACK = "DROP_BACK",
-    COOP = 'CO-OP',
+    COOP = 'COOP',
     GRADUATED = 'GRADUATED'
 }
 


### PR DESCRIPTION
Have to match the values of a status for frontend and backend. Frontend would get a syntax error when status was 'CO-OP' so I changed it to 'COOP'

Filtering gpa by min and max doesn't work. Frontend wants to call ‘localhost:3000/students?gpa.min=0&gpa.max=3.5’ instead of ‘localhost:3000/students?gpa[min]=0&gpa[max]=3.5’. Only way I could get it to work is if I changed the filtering to filter by min and max or just equal. Only downside is that you wont be able to query for two or more exact gpas. But frontend does a range in their filtering anyways so we should be fine.

For a range: 'localhost:3000/students?gpa=3.0&gpa=3.5'
For exact: 'localhost:3000/students?gpa=3.0'

There will probably need to be more changes...hopefully not