### PR TITLE
convert pk type to bigint/long

### DIFF
--- a/src/entity/Course.ts
+++ b/src/entity/Course.ts
@@ -8,8 +8,8 @@ import { IsInt, Length} from "class-validator";
 export class Course {
 
 
-    @PrimaryGeneratedColumn("uuid")
-    id: string;
+    @PrimaryGeneratedColumn()
+    id: bigint;
 
     @Column()
     @Length(2,4)

--- a/src/entity/Exam.ts
+++ b/src/entity/Exam.ts
@@ -5,8 +5,8 @@ import {StudentExam} from "./StudentExam";
 @Entity()
 export class Exam {
 
-    @PrimaryGeneratedColumn("uuid")
-    id: string;
+    @PrimaryGeneratedColumn()
+    id: bigint;
 
     @Column()
     name: string;

--- a/src/entity/Note.ts
+++ b/src/entity/Note.ts
@@ -4,8 +4,8 @@ import { Student } from "./Student";
 @Entity()
 export class Note {
 
-    @PrimaryGeneratedColumn("uuid")
-    id: string;
+    @PrimaryGeneratedColumn()
+    id: bigint;
 
     // date created/modified should be automatic for all entities
 

--- a/src/entity/StudentCourse.ts
+++ b/src/entity/StudentCourse.ts
@@ -8,8 +8,8 @@ import {LetterGrade, Semester} from "./Enums";
 @Unique(["student", "course"])
 export class StudentCourse {
 
-    @PrimaryGeneratedColumn("uuid")
-    id: string;
+    @PrimaryGeneratedColumn()
+    id: bigint;
 
     @Column({
         type: "enum",

--- a/src/entity/StudentExam.ts
+++ b/src/entity/StudentExam.ts
@@ -8,8 +8,8 @@ import {LetterGrade, Semester} from "./Enums";
 @Unique(["studentId", "examId"])
 export class StudentExam {
 
-    @PrimaryGeneratedColumn("uuid")
-    id: string;
+    @PrimaryGeneratedColumn()
+    id: bigint;
 
     @Column({
         comment: "NUID"

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -4,8 +4,8 @@ import {AccessLevel} from "./Enums";
 @Entity()
 export class User {
 
-    @PrimaryGeneratedColumn("uuid")
-    id: number;
+    @PrimaryGeneratedColumn()
+    id: bigint;
 
     @Column()
     firstName: string;


### PR DESCRIPTION
issue: https://github.com/sandboxnu/pharmd-tracker-backend/issues/47

Converts all the pks of the entities we have currently to be using `bigint`, the equivalent to `long`, instead of using `uuid`. Briefly did some `POST/GET` calls on a few endpoints and it seems to work fine.

The `Student` entity's pk is untouched since it looks like the id is by `NUID`. 

ALSO, the typeorm docs I read mentioned that `bigint` would actually be mapped to a string instead because of its large size, but that was a lie since the sql db shows numbers for pk column and ids from `GET` are also numbers through a type check.