### PR TITLE
Add course to exam and studentExam queries

### DIFF
--- a/src/controller/ExamController.ts
+++ b/src/controller/ExamController.ts
@@ -1,4 +1,4 @@
-import {getRepository, Raw} from "typeorm";
+import {createQueryBuilder, getRepository, Raw} from "typeorm";
 import {NextFunction, Request, Response} from "express";
 import {Exam} from "../entity/Exam";
 import {StudentExam} from "../entity/StudentExam";
@@ -43,7 +43,8 @@ export class ExamController {
         try {
             const parsedParams = await this.parseQuery(request.query);
             const exams = await this.examRepository.find({
-                where: parsedParams
+                where: parsedParams,
+                relations: ["course"]
             });
             await response.set({
                 'X-Total-Count': exams.length,
@@ -59,7 +60,8 @@ export class ExamController {
     async findById(request: Request, response: Response, next?: NextFunction) {
         try {
             return await this.examRepository.findOne({
-                where: {id: request.params.id}
+                where: {id: request.params.id},
+                relations: ["course"]
             });
         } catch(e) {
             return e;

--- a/src/controller/ExamController.ts
+++ b/src/controller/ExamController.ts
@@ -1,4 +1,4 @@
-import {createQueryBuilder, getRepository, Raw} from "typeorm";
+import { getRepository, Raw} from "typeorm";
 import {NextFunction, Request, Response} from "express";
 import {Exam} from "../entity/Exam";
 import {StudentExam} from "../entity/StudentExam";

--- a/src/controller/StudentExamController.ts
+++ b/src/controller/StudentExamController.ts
@@ -1,4 +1,4 @@
-import {Between, Equal, getRepository, LessThanOrEqual, MoreThanOrEqual, Raw} from "typeorm";
+import {Between, Equal, getRepository } from "typeorm";
 import {NextFunction, Request, Response} from "express";
 import {StudentExam} from "../entity/StudentExam";
 

--- a/src/controller/StudentExamController.ts
+++ b/src/controller/StudentExamController.ts
@@ -28,7 +28,7 @@ export class StudentExamController {
                         case 'year':
                         case 'percentage':
                             if (Array.isArray(value)) {
-                                value.sort()
+                                value.sort();
                                 where[param] = Between(value[0], value[1]);
                             } else {
                                 where[param] = Equal(value);
@@ -48,9 +48,14 @@ export class StudentExamController {
     async filter(request: Request, response: Response, next?: NextFunction) {
         try {
             const parsedParams = await this.parseQuery(request.query);
-            const studentExams = await this.studentExamRepository.find({
-                where: parsedParams
-            });
+            const studentExams = await this.studentExamRepository
+                .createQueryBuilder('studentExam')
+                .where(parsedParams)
+                .leftJoinAndSelect("studentExam.student", "student")
+                .leftJoinAndSelect("studentExam.exam", "exam")
+                .leftJoinAndSelect("exam.course", "course")
+                .getMany()
+            ;
             await response.set({
                 'X-Total-Count': studentExams.length,
                 'Access-Control-Expose-Headers': ['X-Total-Count']
@@ -64,9 +69,14 @@ export class StudentExamController {
     // find a studentExam given its unique id
     async findById(request: Request, response: Response, next?: NextFunction) {
         try {
-            return await this.studentExamRepository.findOne({
-                where: {id: request.params.id}
-            });
+            return await this.studentExamRepository
+                .createQueryBuilder('studentExam')
+                .where({id: request.params.id})
+                .leftJoinAndSelect("studentExam.student", "student")
+                .leftJoinAndSelect("studentExam.exam", "exam")
+                .leftJoinAndSelect("exam.course", "course")
+                .getOne()
+            ;
         } catch(e) {
             return e;
         }


### PR DESCRIPTION
I changed the query for Exam to include the course it belongs to:

```
    {
        "id": 1,
        "name": "Scary Fundies 1 Midterm",
        "course": {
            "id": 1,
            "subject": "CS",
            "number": 2500,
            "name": "Fundamentals of Computer Science I"
        }
    }
```

And did the same for the query for StudentExam:

```
{
    "id": 1,
    "semester": "SP",
    "year": 2021,
    "percentage": 90,
    "letterGrade": "A-",
    "student": {
        "id": "123456789",
        "lastName": "Doe",
        "firstName": "Jane",
        ...
        "leftProgram": false
    },
    "exam": {
        "id": 1,
        "name": "Scary Fundies 1 Midterm",
        "course": {
            "id": 1,
            "subject": "CS",
            "number": 2500,
            "name": "Fundamentals of Computer Science I"
        }
    }
}
```