### PR TITLE
Adding courses to exams and  student exams - fixed second botched merge

### DIFF
--- a/src/controller/ExamController.ts
+++ b/src/controller/ExamController.ts
@@ -42,6 +42,7 @@ class ExamController {
             const parsedParams = await this.parseQuery(request.query);
             const exams = await this.examRepository.find({
                 where: parsedParams,
+                relations: ["course"]
             });
             await response.set({
                 'X-Total-Count': exams.length,

--- a/src/controller/StudentExamController.ts
+++ b/src/controller/StudentExamController.ts
@@ -51,9 +51,14 @@ class StudentExamController {
     async filter(request: Request, response: Response, next?: NextFunction) {
         try {
             const parsedParams = await this.parseQuery(request.query);
-            const studentExams = await this.studentExamRepository.find({
-                where: parsedParams,
-            });
+            const studentExams = await this.studentExamRepository
+                .createQueryBuilder('studentExam')
+                .where(parsedParams)
+                .leftJoinAndSelect("studentExam.student", "student")
+                .leftJoinAndSelect("studentExam.exam", "exam")
+                .leftJoinAndSelect("exam.course", "course")
+                .getMany()
+            ;
             await response.set({
                 'X-Total-Count': studentExams.length,
                 'Access-Control-Expose-Headers': ['X-Total-Count'],
@@ -67,9 +72,14 @@ class StudentExamController {
     // find a studentExam given its unique id
     async findById(request: Request, response: Response, next?: NextFunction) {
         try {
-            return await this.studentExamRepository.findOne({
-                where: { id: request.params.id },
-            });
+            return await this.studentExamRepository
+                .createQueryBuilder('studentExam')
+                .where({id: request.params.id})
+                .leftJoinAndSelect("studentExam.student", "student")
+                .leftJoinAndSelect("studentExam.exam", "exam")
+                .leftJoinAndSelect("exam.course", "course")
+                .getOne()
+            ;
         } catch (e) {
             return e;
         }


### PR DESCRIPTION
This is literally what was on the first PR I made, but I kept messing up the merge conflicts. But this is the one!

Copy-pasted info from first PR:
I changed the query for Exam to include the course it belongs to:

    {
        "id": 1,
        "name": "Scary Fundies 1 Midterm",
        "course": {
            "id": 1,
            "subject": "CS",
            "number": 2500,
            "name": "Fundamentals of Computer Science I"
        }
    }

And did the same for the query for StudentExam:

{
    "id": 1,
    "semester": "SP",
    "year": 2021,
    "percentage": 90,
    "letterGrade": "A-",
    "student": {
        "id": "123456789",
        "lastName": "Doe",
        "firstName": "Jane",
        ...
        "leftProgram": false
    },
    "exam": {
        "id": 1,
        "name": "Scary Fundies 1 Midterm",
        "course": {
            "id": 1,
            "subject": "CS",
            "number": 2500,
            "name": "Fundamentals of Computer Science I"
        }
    }
}
