### PR TITLE
Filter by multiple cohort

### DIFF
--- a/src/controller/StudentController.ts
+++ b/src/controller/StudentController.ts
@@ -57,6 +57,8 @@ class StudentController {
                     case 'entryDate':
                     case 'originalGradDate':
                     case 'gradDate':
+                        where[param] = Array.isArray(value) ? In(value) : Equal(value);
+                        break;
                     case 'leftProgram':
                         where[param] = Equal(value);
                         break;

--- a/src/controller/__tests__/StudentController.test.ts
+++ b/src/controller/__tests__/StudentController.test.ts
@@ -10,7 +10,7 @@ const student1 = {
     lastName: 'ross',
     firstName: 'bob',
     entryDate: '09/18',
-    gradDate: '05/22',
+    gradDate: '2022',
     originalGradDate: 'Spring 2022',
     status: StudentStatus.ENROLLED,
     gpa: 3.50,
@@ -20,7 +20,7 @@ const student2 = {
     lastName: 'squarepants',
     firstName: 'spongebob',
     entryDate: '09/19',
-    gradDate: '05/23',
+    gradDate: '2023',
     originalGradDate: 'Spring 2022',
     status: StudentStatus.ENROLLED,
     gpa: 3.69,
@@ -30,7 +30,7 @@ const student3 = {
     lastName: 'smith',
     firstName: 'morty',
     entryDate: '09/19',
-    gradDate: '05/22',
+    gradDate: '2022',
     originalGradDate: 'Spring 2022',
     status: StudentStatus.ENROLLED,
     gpa: 2.9,
@@ -115,6 +115,28 @@ describe('test each action in the student controller', () => {
             expect(res.set).toHaveBeenCalled();
             expect(result).toHaveLength(1);
             expect(result[0].id).toStrictEqual('000111222');
+        });
+        it('should return all students in same cohort', async () => {
+            const query = {
+                gradDate: ['2022', '2023'],
+            };
+            const reqWithQuery = MockFunctions.mockRequest({}, query, {});
+            await controller.save(req1, {});
+
+            const result = await controller.filter(reqWithQuery, res);
+            expect(res.set).toHaveBeenCalled();
+            expect(result).toHaveLength(3);
+        });
+        it('should return all students in single cohort', async () => {
+            const query = {
+                gradDate: '2022',
+            };
+            const reqWithQuery = MockFunctions.mockRequest({}, query, {});
+            await controller.save(req1, {});
+
+            const result = await controller.filter(reqWithQuery, res);
+            expect(res.set).toHaveBeenCalled();
+            expect(result).toHaveLength(2);
         });
     });
 });


### PR DESCRIPTION
Issue: https://github.com/sandboxnu/pharmd-tracker/issues/41

I noticed on the frontend that multiple cohorts filtering wasn't supported, so this should add the feature to do so. Also added a couple tests along with it.

One thing I want to bring up is how we're exactly representing cohort or `gradDate` since the dummy data that we have seeded are by years `2022` and `2023` but I see some instances where we use month and year like `05/22`.